### PR TITLE
Xml parsing errors with XmlReader now rethrow as ServiceUnavailableEx…

### DIFF
--- a/src/Reader/XmlReader.php
+++ b/src/Reader/XmlReader.php
@@ -4,6 +4,7 @@ namespace Icecave\Siphon\Reader;
 use Exception;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\XmlParseException;
 use Icecave\Siphon\Reader\Exception\NotFoundException;
 use Icecave\Siphon\Reader\Exception\ServiceUnavailableException;
 use SimpleXMLElement;
@@ -48,7 +49,13 @@ class XmlReader implements XmlReaderInterface
             throw new ServiceUnavailableException($e);
         }
 
-        return $response->xml();
+        try {
+            $xml = $response->xml();
+        } catch (XmlParseException $e) {
+            throw new ServiceUnavailableException($e);
+        }
+
+        return $xml;
     }
 
     private $urlBuilder;

--- a/test/suite/Reader/XmlReaderTest.php
+++ b/test/suite/Reader/XmlReaderTest.php
@@ -5,6 +5,7 @@ use Eloquent\Phony\Phpunit\Phony;
 use Exception;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\XmlParseException;
 use GuzzleHttp\Message\RequestInterface as HttpRequestInterface;
 use GuzzleHttp\Message\ResponseInterface as HttpResponseInterface;
 use Icecave\Siphon\Reader\Exception\NotFoundException;
@@ -120,6 +121,25 @@ class XmlReaderTest extends PHPUnit_Framework_TestCase
         $this
             ->httpClient
             ->get
+            ->throws($exception);
+
+        $this->setExpectedException(
+            ServiceUnavailableException::class,
+            'Service unavailable.'
+        );
+
+        $this->reader->read(
+            'path/to/feed'
+        );
+    }
+
+    public function testXmlParseErrorWithServiceUnavailableException()
+    {
+        $exception = new XmlParseException('The exception!');
+
+        $this
+            ->response
+            ->xml
             ->throws($exception);
 
         $this->setExpectedException(


### PR DESCRIPTION
Rethrows Xml Parse errors as service unavailable exception.